### PR TITLE
Run the windows process without cmd.

### DIFF
--- a/src/main/groovy/com/pros/gradle/ZapPlugin.groovy
+++ b/src/main/groovy/com/pros/gradle/ZapPlugin.groovy
@@ -74,7 +74,7 @@ class ZapStart extends DefaultTask {
             ProcessBuilder builder = null
             if (Os.isFamily(Os.FAMILY_WINDOWS))
             {
-                builder = new ProcessBuilder("cmd", "/c", "java -jar zap.jar -daemon -port ${project.zapConfig.proxyPort.toInteger()}")
+                builder = new ProcessBuilder("java","-jar", "zap.jar", "-daemon", "-port", "${project.zapConfig.proxyPort.toInteger()}")
             }
             else
             {


### PR DESCRIPTION
The waitForOrKill on windows has different behaviour than it has on unix. It doesn't kill whole the process tree, it just kills the cmd.exe and leaves zap running.

Running zap this way kills the java process that runs zap
